### PR TITLE
Fix for potential issue where application is using both aws-s3 and right_http_connection

### DIFF
--- a/lib/net_fix.rb
+++ b/lib/net_fix.rb
@@ -82,7 +82,14 @@ module Net
       if @body
         send_request_with_body sock, ver, path, @body, send_only
       elsif @body_stream
-        send_request_with_body_stream sock, ver, path, @body_stream, send_only
+        begin
+          send_request_with_body_stream sock, ver, path, @body_stream, send_only
+        rescue ArgumentError
+          # this rescue is called when users have both net_http_connection and aws-s3 gem installed.
+          # For whatever reason, sometimes this method gets redefined by aws-s3 (depending on load order)
+          # the aws-s3 gem only has 4 options, not 5, so users see an ArgumentError (5 for 4) when this gets called.
+          send_request_with_body_stream sock, ver, path, @body_stream
+        end
       else
         write_header(sock, ver, path)
       end


### PR DESCRIPTION
Sometimes applications are using both right_aws AND aws-s3.  This is notably true with the paper_clip gem, which is relying on aws-s3.

Both right_http_connection and aws-s3 do a few tricks with Net::HTTP.  My patch will rescue an error where `send_request_with_body_stream` is potentially redefined by aws-s3.  Their version only takes 4 arguments, as opposed to your 5.
