### PR TITLE
Set correct content-length for possible multibyte strings

### DIFF
--- a/lib/net_fix.rb
+++ b/lib/net_fix.rb
@@ -91,7 +91,7 @@ module Net
     private
 
     def send_request_with_body(sock, ver, path, body, send_only=nil)
-      self.content_length = body.length
+      self.content_length = body.respond_to?(:bytesize) ? body.bytesize : body.length
       delete 'Transfer-Encoding'
       supply_default_content_type
       write_header(sock, ver, path) unless send_only == :body


### PR DESCRIPTION
Found out that this gem was the culprit when sending standard ruby http requests with multibyte chars in ruby 1.9. (I didn't use your gem directly but it was included as a dependency from another gem, rest-client, which overwrote the standard request method).
The content-length http header was set to number of chars, not number of bytes.
