### PR TITLE
refs #13307 - remove ssl logging stuff due it's useless

### DIFF
--- a/lib/right_http_connection.rb
+++ b/lib/right_http_connection.rb
@@ -310,12 +310,6 @@ them.
           # List of error codes: http://www.openssl.org/docs/apps/verify.html
           code = x509_store_ctx.error
           msg = x509_store_ctx.error_string
-            #debugger
-          if code == 0
-            @logger.info "##### Certificate verification passed. #####"
-          else
-            @logger.warn("##### #{@server} certificate verify failed: #{msg}")
-          end
           if request_params[:fail_if_ca_mismatch] && code != 0
             false
           else


### PR DESCRIPTION
Initially we decide to remove ssl logging because there are too
many logs connected with that. We don't need to log this stuff,
because if there is problem with authorization then the server
will return appropriate status code in the response.
