### PR TITLE
Response body is not decoded correctly

### DIFF
--- a/lib/base/net_fix.rb
+++ b/lib/base/net_fix.rb
@@ -162,7 +162,7 @@ module Net
         req.exec @socket, @curr_http_version, edit_path(req.path), send_only
         begin
           res = HTTPResponse.read_new(@socket)
-          res.decode_content = req.decode_content
+          res.decode_content = req.decode_content if RUBY_VERSION > '2.0'
           # if we expected 100-continue then send a body
           if res.is_a?(HTTPContinue) && send_only && req['content-length'].to_i > 0
             req.exec @socket, @curr_http_version, edit_path(req.path), :body


### PR DESCRIPTION
This commit changed the way Ruby decodes response body:

https://github.com/ruby/ruby/commit/ddddf044b27c87b0b2d5b31bb1ed2277f211ec1e

Without the line of code that I ported, gzip content from response body will not be automatically decoded. This will break gems such as postmark.
