### PR TITLE
Use Timeout.timeout over bare timeout

### DIFF
--- a/lib/base/net_fix.rb
+++ b/lib/base/net_fix.rb
@@ -24,7 +24,7 @@
 
 # Net::HTTP and Net::HTTPGenericRequest fixes to support 100-continue on 
 # POST and PUT. The request must have 'expect' field set to '100-continue'.
-
+require 'timeout'
 
 module Net
   
@@ -48,7 +48,7 @@ module Net
     end
 
     def rbuf_fill
-      timeout(@read_timeout) {
+      Timeout.timeout(@read_timeout) {
         @rbuf << @io.sysread(@@socket_read_size)
       }
     end


### PR DESCRIPTION
As of Ruby 2.3.3, Object#timeout is deprecated:

```
right_http_connection-1.5.0/lib/base/net_fix.rb:51:in `rbuf_fill': Object#timeout is deprecated, use Timeout.timeout instead.
```

This replaces the call to `timeout` with `Timeout.timeout`.

It's unclear to me if this gem is maintained. If it isn't, feel free to close this PR. In the meantime, I've modified our app to use a fork of the gem instead so no rush.

Thanks!